### PR TITLE
Fix display of price after discount

### DIFF
--- a/src/components/Chart/Chart.tsx
+++ b/src/components/Chart/Chart.tsx
@@ -31,7 +31,7 @@ const Chart = ({ data }: Props) => {
     return {
       name: item.title,
       p: item.price,
-      dp: item.discountedPrice,
+      dp: Number((item.discountedPrice / item.quantity).toFixed(2)),
     }
   })
 

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -8,13 +8,14 @@ type Props = {
   item: Product
 }
 const ProductCard = ({ item }: Props) => {
+  const discountedPrice = Number((item.discountedPrice / item.quantity).toFixed(2))
   return (
     <div className={styles.container}>
       <h3>{item.title}</h3>
       <p>product id: {item.id}</p>
       <p className={clsx(styles.tagline, 'line-through')}>price: {item.price}</p>
-      <h6 className={clsx(styles.tagline, (item.discountedPrice > item.price) ? 'text-red-600' : 'text-green-600')}>discounted price: {item.discountedPrice}</h6>
-      <p className='flex items-center gap-1'>discount: {item.discountPercentage} % {(item.discountedPrice > item.price) ? <ArrowUpIcon className='h-[1em] text-red-600' /> : <ArrowDownIcon className='h-[1em] text-green-600' />}</p>
+      <h6 className={clsx(styles.tagline, (discountedPrice > item.price) ? 'text-red-600' : 'text-green-600')}>price after discount: {discountedPrice}</h6>
+      <p className='flex items-center gap-1'>discount: {item.discountPercentage} % {(discountedPrice > item.price) ? <ArrowUpIcon className='h-[1em] text-red-600' /> : <ArrowDownIcon className='h-[1em] text-green-600' />}</p>
     </div>
   )
 }

--- a/src/components/ProductsListItem/ProductsListItem.tsx
+++ b/src/components/ProductsListItem/ProductsListItem.tsx
@@ -12,13 +12,15 @@ type Props = {
 }
 
 const ProductsListItem = ({ item }: Props) => {
+  const discountedPrice = Number((item.discountedPrice / item.quantity).toFixed(2))
+
   return (
     <GridListItem>
       <div className={styles.container}>
         <div className={styles.info}>
           <h4 className={styles.name}>{item.title}</h4>
           <p className={clsx(styles.tagline, 'line-through')}>price: {item.price}</p>
-          <h6 className={clsx(styles.tagline, (item.discountedPrice > item.price) ? 'text-red-600' : 'text-green-600')}>discounted price: {item.discountedPrice}</h6>
+          <h6 className={clsx(styles.tagline, (discountedPrice > item.price) ? 'text-red-600' : 'text-green-600')}>price after discount: {discountedPrice}</h6>
         </div>
         <MyPopover button={<Button>Show details</Button>}>
           <ProductCard item={item} />


### PR DESCRIPTION
The item's discounted price should be divided
by the quantity of products, otherwise the
displayed price is possibly few times bigger
than expected.